### PR TITLE
Add in ability to pass options to apt-get/dpkg

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,5 +23,5 @@ jobs:
       - uses: ./
         with:
           arch: armhf
-          dpg_options: "--force-overwrite"
+          dpkg_options: "--force-overwrite"
           packages: "libsqlite3-dev:armhf libc6-dev:armhf"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,5 +23,5 @@ jobs:
       - uses: ./
         with:
           arch: armhf
-          options: "--force-overwrite"
+          dpg_options: "--force-overwrite"
           packages: "libsqlite3-dev:armhf libc6-dev:armhf"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,24 @@ on: # rebuild any PRs and main branch changes
   push:
     branches:
       - master
-      - 'releases/*'
+      - "releases/*"
 
 jobs:
   test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: ./
-      with:
-        arch: armhf
-        packages: "libsqlite3-dev:armhf libc6-dev:armhf"
+      - uses: actions/checkout@v2
+      - uses: ./
+        with:
+          arch: armhf
+          packages: "libsqlite3-dev:armhf libc6-dev:armhf"
+
+  test_options: # make sure the action works on a clean machine without building
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        with:
+          arch: armhf
+          options: "--force-overwrite"
+          packages: "libsqlite3-dev:armhf libc6-dev:armhf"

--- a/README.md
+++ b/README.md
@@ -9,10 +9,19 @@ If you just need to install packages, use a `run: sudo apt-get install -y PACKAG
 
 This patches the existing apt repositories on the system, adds the specified architecture via multiarch, adds a set of viable port repositories, and finally updates the cache and installs the specified packages.
 
-
 ```yaml
   - uses: ryankurte/action-apt@v0.3.0
     with:
       arch: armhf
       packages: "libsqlite3-dev:armhf"
+```
+
+Optionally, you can pass `dpkg` options to the `apt-get` install command using `dpg_options`
+
+```yaml
+      - uses: ./
+        with:
+          arch: armhf
+          dpkg_options: "--force-overwrite"
+          packages: "libsqlite3-dev:armhf libc6-dev:armhf"
 ```

--- a/action.yml
+++ b/action.yml
@@ -45,9 +45,10 @@ runs:
       run: sudo apt-get update
 
     - name: "Discover options"
+      id: options_configured
       shell: bash
       run: |
-        echo '::set-output options_configured=Dpkg::Options::="{{ inputs.options }}"'
+        echo '::set-output name=Dpkg::Options::="{{ inputs.options }}"'
 
     - name: "Install packages"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -44,15 +44,9 @@ runs:
       shell: bash
       run: sudo apt-get update
 
-    - name: "Discover options"
-      id: options_configured
-      shell: bash
-      run: |
-        echo '::set-output name=Dpkg::Options::="{{ inputs.options }}"'
-
     - name: "Install packages"
       shell: bash
-      run: sudo apt-get install -y ${{ inputs.packages }} ${{ inputs.options_configured }}
+      run: sudo apt-get install -y ${{ inputs.packages }} -f -o Dpkg::Options::="${{ inputs.options }}"
 
 branding:
   icon: "arrow-down-circle"

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
   packages:
     description: "List of packages to install"
     required: true
+  dpkg_options:
+    description: "Additional options to pass to dpkg"
+    required: false
+
 outputs:
   distro:
     description: "Detected ubuntu distribution"
@@ -46,7 +50,7 @@ runs:
 
     - name: "Install packages"
       shell: bash
-      run: sudo apt-get install -y ${{ inputs.packages }} -f -o Dpkg::Options::="${{ inputs.options }}"
+      run: sudo apt-get install -y ${{ inputs.packages }} -f -o Dpkg::Options::="${{ inputs.dpkg_options }}"
 
 branding:
   icon: "arrow-down-circle"

--- a/action.yml
+++ b/action.yml
@@ -1,20 +1,20 @@
-name: 'apt multiarch helper action'
-description: 'Use apt to setup a foreign architecture (multiarch) and install packages on ubuntu'
-author: 'ryan kurte'
+name: "apt multiarch helper action"
+description: "Use apt to setup a foreign architecture (multiarch) and install packages on ubuntu"
+author: "ryan kurte"
 inputs:
   arch:
-    description: 'Foreign architecture to configure'
+    description: "Foreign architecture to configure"
     required: true
   packages:
-    description: 'List of packages to install'
+    description: "List of packages to install"
     required: true
 outputs:
-  distro: 
+  distro:
     description: "Detected ubuntu distribution"
     value: ${{ steps.discover-distro.outputs.distro }}
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: "Patch azure archives for [amd64, i386] use only"
       shell: bash
@@ -44,10 +44,15 @@ runs:
       shell: bash
       run: sudo apt-get update
 
+    - name: "Discover options"
+      shell: bash
+      run: |
+        echo '::set-output options_configured=Dpkg::Options::="{{ inputs.options }}"'
+
     - name: "Install packages"
       shell: bash
-      run: sudo apt-get install -y ${{ inputs.packages }}
+      run: sudo apt-get install -y ${{ inputs.packages }} ${{ inputs.options_configured }}
 
 branding:
-  icon: 'arrow-down-circle'  
-  color: 'blue'
+  icon: "arrow-down-circle"
+  color: "blue"


### PR DESCRIPTION
Thank you for this action!

I have run in to an issue with a package/arch combo that requires me to have `apt-get` set some `Dpkg::Options::=` to enable it to install correctly. This PR enables that functionality and updates the readme to reflect the changes.